### PR TITLE
BOM-1577: Added python 3.8 in test matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,15 +6,19 @@ language: python
 sudo: false
 python:
   - 3.5
+  - 3.8
 env:
-  - TOX_ENV=csslint
-  - TOX_ENV=eslint
-  - TOX_ENV=pycodestyle
-  - TOX_ENV=pylint
-  - TOX_ENV=py35-django111
-  - TOX_ENV=py35-django20
-  - TOX_ENV=py35-django21
-  - TOX_ENV=py35-django22
+  - TOX_ENV=django22
+matrix:
+  include:
+    - python: 3.5
+      env: TOX_ENV=csslint
+    - python: 3.5
+      env: TOX_ENV=eslint
+    - python: 3.5
+      env: TOX_ENV=pycodestyle
+    - python: 3.5
+      env: TOX_ENV=pylint
 before_install:
   - "pip install -U pip"
   - export BOTO_CONFIG=/dev/null

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ setup(
         'qualtricssurvey',
     ],
     install_requires=[
-        'Django',
+        'Django<3.0',
         'edx-opaque-keys',
         'mock',
         'six',

--- a/tox.ini
+++ b/tox.ini
@@ -1,12 +1,10 @@
 [tox]
-envlist = csslint,eslint,py35-django{111,20,21,22},pycodestyle,pylint
+envlist = csslint,eslint,py{35,38}-django{22,30},pycodestyle,pylint
 
 [testenv]
 deps =
-    django111: Django>=1.11,<2.0
-    django20: Django>=2.0,<2.1
-    django21: Django>=2.1,<2.2
     django22: Django>=2.2,<2.3
+    django30: Django>=3.0,<3.1
     coverage
 commands =
     coverage run manage.py test


### PR DESCRIPTION
- Added python3.8 travis worker
- Added Django 3.0 in tox file for testing
- Removed support for python < 3.5 and Django < 2.2

https://openedx.atlassian.net/browse/BOM-1577